### PR TITLE
Update example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ and using the callback to call several methods on the redirect middleware to cha
 
 ```php
 $loop = Factory::create(); 
-$server = new Server(new MiddlewareRunner([
+$server = new Server([
     /** Other middleware */
     new PSR15Middleware(
         $loop, // The react/event-loop (required) 
@@ -36,7 +36,7 @@ $server = new Server(new MiddlewareRunner([
         }
     ),
     /** Other middleware */
-]));
+]);
 ```
 
 # Warning


### PR DESCRIPTION
The package has a dependency of `"react/http": "^0.8.0"`, so we can simply pass an array of middleware to `Server` constructor. There is no need to explicitly create an instance of `MiddlewareRunner`.