### PR TITLE
Replace magic __DIR__ and __FILE__ constants with a string representing the original __DIR__ and __FILE__

### DIFF
--- a/src/YieldingMiddlewareFactory.php
+++ b/src/YieldingMiddlewareFactory.php
@@ -2,9 +2,14 @@
 
 namespace FriendsOfReact\Http\Middleware\Psr15Adapter;
 
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\BinaryOp\Concat;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Expr\Yield_;
+use PhpParser\Node\Scalar\MagicConst\Dir;
+use PhpParser\Node\Scalar\MagicConst\File;
+use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\ParserFactory;
@@ -21,7 +26,7 @@ final class YieldingMiddlewareFactory
 
         foreach (get_declared_classes() as $class) {
             if (strpos($class, 'ComposerAutoloaderInit') === 0) {
-                $file = $class::getLoader()->findFile($middleware);
+                $file = realpath($class::getLoader()->findFile($middleware));
                 break;
             }
         }
@@ -30,9 +35,10 @@ final class YieldingMiddlewareFactory
             throw new \Exception('Could not find composer loader');
         }
 
+        $dir = realpath(dirname($file));
         $parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
         $stmts = $parser->parse(file_get_contents($file));
-        $stmts = self::iterateStmts($stmts);
+        $stmts = self::iterateStmts($stmts, $dir, $file);
         $prettyPrinter = new Standard();
         $code = $prettyPrinter->prettyPrint($stmts);
 
@@ -45,7 +51,7 @@ final class YieldingMiddlewareFactory
         return new $FQCN(...$arguments);
     }
 
-    private static function iterateStmts(array $stmts): array
+    private static function iterateStmts(array $stmts, string $dir, string $file): array
     {
         foreach ($stmts as &$stmt) {
             if ($stmt instanceof Class_) {
@@ -58,30 +64,52 @@ final class YieldingMiddlewareFactory
             }
 
             if (isset($stmt->stmts)) {
-                $stmt->stmts = static::iterateStmts($stmt->stmts);
+                $stmt->stmts = static::iterateStmts($stmt->stmts, $dir, $file);
             }
 
-            $stmt = static::checkStmt($stmt);
+            $stmt = static::checkStmt($stmt, $dir, $file);
         }
         return $stmts;
     }
 
-    private static function checkStmt($stmt)
+    private static function checkStmt($stmt, string $dir, string $file)
     {
         if (isset($stmt->stmts)) {
-            $stmt->stmts = static::iterateStmts($stmt->stmts);
+            $stmt->stmts = static::iterateStmts($stmt->stmts, $dir, $file);
         }
 
         if (isset($stmt->expr)) {
-            $stmt->expr = static::checkStmt($stmt->expr);
-            return $stmt;
+            $stmt->expr = static::checkStmt($stmt->expr, $dir, $file);
+        }
+
+        if (isset($stmt->args)) {
+            $stmt->args = static::iterateStmts($stmt->args, $dir, $file);
         }
 
         if ($stmt instanceof MethodCall) {
             if ($stmt->var instanceof Variable && $stmt->var->name == 'handler' && $stmt->name == 'handle') {
                 return new Yield_($stmt);
             }
-            $stmt->var = static::checkStmt($stmt->var);
+            $stmt->var = static::checkStmt($stmt->var, $dir, $file);
+            return $stmt;
+        }
+
+        if ($stmt instanceof Dir) {
+            return new String_($dir);
+        }
+
+        if ($stmt instanceof File) {
+            return new String_($file);
+        }
+
+        if ($stmt instanceof Concat) {
+            $stmt->left = self::checkStmt($stmt->left, $dir, $file);
+            $stmt->right = self::checkStmt($stmt->right, $dir, $file);
+            return $stmt;
+        }
+
+        if ($stmt instanceof Arg) {
+            $stmt->value = self::checkStmt($stmt->value, $dir, $file);
             return $stmt;
         }
 

--- a/tests/PSR15MiddlewareTest.php
+++ b/tests/PSR15MiddlewareTest.php
@@ -27,5 +27,6 @@ final class PSR15MiddlewareTest extends TestCase
 
         self::assertSame(200, $response->getStatusCode());
         self::assertSame('passed', $response->getHeaderLine('X-Test'));
+        self::assertSame('__DIR__:' . __DIR__ . ';__FILE__:' . __DIR__ . DIRECTORY_SEPARATOR  . 'PSR15TestMiddleware.php', (string)$response->getBody());
     }
 }

--- a/tests/PSR15TestMiddleware.php
+++ b/tests/PSR15TestMiddleware.php
@@ -6,6 +6,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface as PSR15MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use function RingCentral\Psr7\stream_for;
 
 final class PSR15TestMiddleware implements PSR15MiddlewareInterface
 {
@@ -13,6 +14,7 @@ final class PSR15TestMiddleware implements PSR15MiddlewareInterface
     {
         $response = $handler->handle($request);
         $response = $response->withHeader('X-Test', 'passed');
+        $response = $response->withBody(stream_for('__DIR__:' . __DIR__ . ';__FILE__:' . __FILE__));
         return $response;
     }
 }


### PR DESCRIPTION
Fixes / Closes #4 

Ran into this issue when using a middleware that relies on those magic constants. It couldn't find the file it was looking for because `__DIR__` and `__FILE__` where now the ones for `YieldingMiddlewareFactory`.